### PR TITLE
BUGFIX: Fixed issue causing dragTo() to not actually perform the drag.

### DIFF
--- a/src/FacebookWebDriver.php
+++ b/src/FacebookWebDriver.php
@@ -971,7 +971,7 @@ JS;
     {
         $source = $this->findElement($sourceXpath);
         $destination = $this->findElement($destinationXpath);
-        $this->webDriver->action()->dragAndDrop($source, $destination);
+        $this->webDriver->action()->dragAndDrop($source, $destination)->perform();
     }
 
     /**


### PR DESCRIPTION
The ``FacebookWebDriver::dragTo()`` method does not actually perform the drag and drop, this seems to be due to a missing ``perform()`` call. Adding that call to the method chain seems to address the issue and actually perform the drag.

__Tested With:__
silverstripe/recipe-cms: 4.3.0
silverstripe/behat-extension: 4.1.0
silverstripe/mink-facebook-web-driver: 1.0.0
facebook/webdriver: 1.6.0
behat/behat: 3.5.0