### PR TITLE
FIX: Fixed compatibility with facebook/webdriver 1.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": "^5.6 | ^7",
         "behat/mink": "~1.7@dev",
-        "facebook/webdriver": "^1.4"
+        "facebook/webdriver": "^1.7"
     },
     "require-dev": {
         "mink/driver-testsuite": "dev-master"

--- a/src/FacebookWebDriver.php
+++ b/src/FacebookWebDriver.php
@@ -14,6 +14,7 @@ use Behat\Mink\Driver\CoreDriver;
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Selector\Xpath\Escaper;
 use Exception;
+use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
@@ -222,12 +223,16 @@ class FacebookWebDriver extends CoreDriver
      */
     protected function initChromeCapabilities(DesiredCapabilities $caps, $config)
     {
-        $chromeOptions = [];
+        $chromeOptions = new ChromeOptions();
         foreach ($config as $capability => $value) {
             if ($capability == 'switches') {
-                $chromeOptions['args'] = $value;
+                $chromeOptions->addArguments($value);
+            } elseif ($capability == 'binary') {
+                $chromeOptions->setBinary($value);
+            } elseif ($capability == 'extensions') {
+                $chromeOptions->addExtensions($value);
             } else {
-                $chromeOptions[$capability] = $value;
+                $chromeOptions->setExperimentalOption($capability, $value);
             }
             $caps->setCapability('chrome.'.$capability, $value);
         }


### PR DESCRIPTION
This pull request fixes compatibility with facebook/webdriver 1.7.0 and ChromeDriver 75, this also bumps the base requirement for facebook/webdriver to ^1.7 just in case the 1.4 version is not supporting the ChromeOptions object.