### PR TITLE
Search for options within parent

### DIFF
--- a/src/FacebookWebDriver.php
+++ b/src/FacebookWebDriver.php
@@ -1143,7 +1143,7 @@ XPATH;
         $escapedValue = $this->xpathEscaper->escapeLiteral($value);
         // The value of an option is the normalized version of its text when it has no value attribute
         $optionQuery = sprintf('.//option[@value = %s or (not(@value) and normalize-space(.) = %s)]', $escapedValue, $escapedValue);
-        $option = $this->findElement($optionQuery);
+        $option = $this->findElement($optionQuery, $element);
 
         if ($multiple || !$element->getAttribute('multiple')) {
             if (!$option->isSelected()) {


### PR DESCRIPTION
When searching for option elements, we must limit the scope of the find
to the select that they belong to.

Where multiple select fields exist on the page, and they have options
children with the same value, the first one on the page was being
selected rather than the intended one.