### PR TITLE
Functions on the driver should be protected

### DIFF
--- a/src/FacebookWebDriver.php
+++ b/src/FacebookWebDriver.php
@@ -39,41 +39,41 @@ class FacebookWebDriver extends CoreDriver
      *
      * @var string
      */
-    private $webDriverHost = null;
+    protected $webDriverHost = null;
 
     /**
      * Whether the browser has been started
      * @var Boolean
      */
-    private $started = false;
+    protected $started = false;
 
     /**
      * The WebDriver instance
      *
      * @var RemoteWebDriver
      */
-    private $webDriver;
+    protected $webDriver;
 
     /**
      * @var string
      */
-    private $browserName;
+    protected $browserName;
 
     /**
      * @var DesiredCapabilities
      */
-    private $desiredCapabilities;
+    protected $desiredCapabilities;
 
     /**
      * The timeout configuration
      * @var array
      */
-    private $timeouts = [];
+    protected $timeouts = [];
 
     /**
      * @var Escaper
      */
-    private $xpathEscaper;
+    protected $xpathEscaper;
 
     /**
      * Instantiates the driver.
@@ -353,7 +353,7 @@ class FacebookWebDriver extends CoreDriver
      *
      * @return mixed
      */
-    private function executeJsOnElement(RemoteWebElement $element, $script, $sync = true)
+    protected function executeJsOnElement(RemoteWebElement $element, $script, $sync = true)
     {
         $script  = str_replace('{{ELEMENT}}', 'arguments[0]', $script);
         if ($sync) {
@@ -398,7 +398,7 @@ class FacebookWebDriver extends CoreDriver
      *
      * @throws DriverException
      */
-    private function applyTimeouts()
+    protected function applyTimeouts()
     {
         try {
             $timeouts = $this->webDriver->manage()->timeouts();
@@ -843,7 +843,7 @@ JS;
      *
      * @param RemoteWebElement $element
      */
-    private function clickOnElement(RemoteWebElement $element)
+    protected function clickOnElement(RemoteWebElement $element)
     {
         $element->getLocationOnScreenOnceScrolledIntoView();
         $element->click();
@@ -862,7 +862,7 @@ JS;
      *
      * @param RemoteWebElement $element
      */
-    private function doubleClickOnElement(RemoteWebElement $element)
+    protected function doubleClickOnElement(RemoteWebElement $element)
     {
         $element->getLocationOnScreenOnceScrolledIntoView();
         $this->webDriver->getMouse()->doubleClick($element->getCoordinates());
@@ -876,7 +876,7 @@ JS;
         $this->rightClickOnElement($this->findElement($xpath));
     }
 
-    private function rightClickOnElement(RemoteWebElement $element)
+    protected function rightClickOnElement(RemoteWebElement $element)
     {
         $element->getLocationOnScreenOnceScrolledIntoView();
         $this->webDriver->getMouse()->contextClick($element->getCoordinates());
@@ -915,7 +915,7 @@ JS;
      *
      * @param RemoteWebElement $element
      */
-    private function mouseOverElement(RemoteWebElement $element)
+    protected function mouseOverElement(RemoteWebElement $element)
     {
         $element->getLocationOnScreenOnceScrolledIntoView();
         $this->webDriver->getMouse()->mouseMove($element->getCoordinates());
@@ -1068,7 +1068,7 @@ JS;
      * @param RemoteWebElement|null $parent Optional parent element
      * @return RemoteWebElement
      */
-    private function findElement($xpath, RemoteWebElement $parent = null)
+    protected function findElement($xpath, RemoteWebElement $parent = null)
     {
         $finder = WebDriverBy::xpath($xpath);
         return $parent
@@ -1084,7 +1084,7 @@ JS;
      *
      * @throws DriverException when the value cannot be found
      */
-    private function selectRadioValue(RemoteWebElement $element, $value)
+    protected function selectRadioValue(RemoteWebElement $element, $value)
     {
         // short-circuit when we already have the right button of the group to avoid XPath queries
         if ($element->getAttribute('value') === $value) {
@@ -1138,7 +1138,7 @@ XPATH;
      * @param string  $value
      * @param bool    $multiple
      */
-    private function selectOptionOnElement(RemoteWebElement $element, $value, $multiple = false)
+    protected function selectOptionOnElement(RemoteWebElement $element, $value, $multiple = false)
     {
         $escapedValue = $this->xpathEscaper->escapeLiteral($value);
         // The value of an option is the normalized version of its text when it has no value attribute
@@ -1165,7 +1165,7 @@ XPATH;
      *
      * @param RemoteWebElement $element
      */
-    private function deselectAllOptions(RemoteWebElement $element)
+    protected function deselectAllOptions(RemoteWebElement $element)
     {
         $script = <<<JS
 var node = {{ELEMENT}};
@@ -1188,7 +1188,7 @@ JS;
      *
      * @throws DriverException
      */
-    private function ensureInputType(RemoteWebElement $element, $xpath, $type, $action)
+    protected function ensureInputType(RemoteWebElement $element, $xpath, $type, $action)
     {
         if ('input' !== $element->getTagName()
             || $type !== $element->getAttribute('type')
@@ -1204,7 +1204,7 @@ JS;
      * @param string $event Event name
      * @param string $options Options to pass to window.syn.trigger
      */
-    private function trigger($xpath, $event, $options = '{}')
+    protected function trigger($xpath, $event, $options = '{}')
     {
         $script = 'window.Syn.trigger("' . $event . '", ' . $options . ', {{ELEMENT}})';
         $this->withSyn()->executeJsOnXpath($xpath, $script);


### PR DESCRIPTION
There is no need for many of these methods to be private, and in fact it
makes it impossible to extend the driver sensibly if they are.

The visibility features of PHP mean that any function called in a parent
class by a child class where that parent function calls a private method
means that it is impossible to override the private methods.

This means that it is not possible, for example, to apply bug fixes
locally.

Take, for example, the case of https://github.com/silverstripe/MinkFacebookWebDriver/pull/3

I am unable to simply override the `selectOptionOnElement` function in my version of the driver because that function is private. It is called by `selectOption` and `setValue`. PHP's visibility rules mean that those functions, which are defined on the Silverstripe Driver only see the Silverstripe implementation of all private functions. They are entirely unaware and unable to see any extension of those functions in the child class.