### PR TITLE
Rename php-webdriver package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": "^5.6 | ^7",
         "behat/mink": "~1.7@dev",
-        "facebook/webdriver": "^1.4"
+        "php-webdriver/webdriver": "^1.4"
     },
     "require-dev": {
         "mink/driver-testsuite": "dev-master"


### PR DESCRIPTION
Php-webdriver package [has been renamed](https://github.com/php-webdriver/php-webdriver/issues/730#issuecomment-575601572) and the original is now marked as abandoned (and will not receive any updates).

```sh
$ composer install
Package facebook/php-webdriver is abandoned, you should avoid using it. Use php-webdriver/webdriver instead.
```