### PR TITLE
FIX Explicitly disable W3C mode for Chrome

### DIFF
--- a/src/FacebookFactory.php
+++ b/src/FacebookFactory.php
@@ -37,6 +37,13 @@ class FacebookFactory extends Selenium2Factory
         // Merge capabilities
         $extraCapabilities = $config['capabilities']['extra_capabilities'];
         unset($config['capabilities']['extra_capabilities']);
+
+        // PATCH: Disable W3C mode in chromedriver until we have capacity to actively adopt it
+        $extraCapabilities['chromeOptions'] = array_merge(
+            $extraCapabilities['chromeOptions'] ?? [],
+            ['w3c' => false]
+        );
+
         $capabilities = array_replace($this->guessCapabilities(), $extraCapabilities, $config['capabilities']);
 
         // Build driver definition


### PR DESCRIPTION
Works around newer Chrome releases enabling W3C mode by default. This is [actively breaking our builds](https://travis-ci.org/dnadesign/silverstripe-elemental/jobs/653273763), likely due to the Chrome packages being updated in Travis CI's `xenial` environment.

See also: https://github.com/webdriverio/webdriverio/issues/4073