### PR TITLE
Do not add chromeOptions to IE capabilities

### DIFF
--- a/src/FacebookFactory.php
+++ b/src/FacebookFactory.php
@@ -39,10 +39,12 @@ class FacebookFactory extends Selenium2Factory
         unset($config['capabilities']['extra_capabilities']);
 
         // PATCH: Disable W3C mode in chromedriver until we have capacity to actively adopt it
-        $extraCapabilities['chromeOptions'] = array_merge(
-            isset($extraCapabilities['chromeOptions']) ? $extraCapabilities['chromeOptions'] : [],
-            ['w3c' => false]
-        );
+        if (!empty($config['capabilities']['browser']) && $config['capabilities']['browser'] != WebDriverBrowserType::IE) {
+            $extraCapabilities['chromeOptions'] = array_merge(
+                isset($extraCapabilities['chromeOptions']) ? $extraCapabilities['chromeOptions'] : [],
+                ['w3c' => false]
+            );
+        }
 
         $capabilities = array_replace($this->guessCapabilities(), $extraCapabilities, $config['capabilities']);
 


### PR DESCRIPTION
First of all - Thank You for this repo. It is working like a charm and saved my day!

About this PR:

It is not possible to start up IE browser (in browserstack) with current configuration. It complains about `chromeOptions` key in `capabilities`.

```
      Behat\Mink\Exception\DriverException: Could not open connection: Invalid option: chromeOptions for browser: ie in vendor/silverstripe/mink-facebook-web-driver/src/FacebookWebDriver.php:375
      Stack trace:
      #0 vendor/friends-of-behat/mink/src/Session.php(70): SilverStripe\MinkFacebookWebDriver\FacebookWebDriver->start()
      #1 vendor/friends-of-behat/mink/src/Session.php(145): Behat\Mink\Session->start()
      #2 vendor/friends-of-behat/mink-extension/src/Behat/MinkExtension/Context/RawMinkContext.php(131): Behat\Mink\Session->visit()
      #3 vendor/friends-of-behat/mink-extension/src/Behat/MinkExtension/Context/MinkContext.php(49): Behat\MinkExtension\Context\RawMinkContext->visitPath()
```

Solution:

Just if statement.
First I checked if browser is chrome but then decided to do other way around and just exclude IE for these params because looks like all other browsers (ff, safari, edge) have no problem with this.