### PR TITLE
FIX Get textarea value for recent version of chrome

### DIFF
--- a/src/FacebookWebDriver.php
+++ b/src/FacebookWebDriver.php
@@ -694,6 +694,15 @@ JS;
             return $this->executeJsOnElement($element, $script);
         }
 
+        // use textarea.value rather than textarea.getAttribute(value) for chrome 91+ support
+        if ('textarea' === $elementName) {
+            $script = <<<JS
+var node = {{ELEMENT}};
+return node.value;
+JS;
+            return $this->executeJsOnElement($element, $script);
+        }
+
         return $element->getAttribute('value');
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1198

Tag 1.1.1 after merge

Travis config is ancient and will not pass, so just ignore failure - https://travis-ci.com/github/silverstripe/MinkFacebookWebDriver/builds/225401051

