### PR TITLE
Avoids selecting values from other select boxes

### DIFF
--- a/src/FacebookWebDriver.php
+++ b/src/FacebookWebDriver.php
@@ -1152,7 +1152,7 @@ XPATH;
         $escapedValue = $this->xpathEscaper->escapeLiteral($value);
         // The value of an option is the normalized version of its text when it has no value attribute
         $optionQuery = sprintf('.//option[@value = %s or (not(@value) and normalize-space(.) = %s)]', $escapedValue, $escapedValue);
-        $option = $this->findElement($optionQuery);
+        $option = $this->findElement($optionQuery, $element); // Avoids selecting values from other select boxes
 
         if ($multiple || !$element->getAttribute('multiple')) {
             if (!$option->isSelected()) {


### PR DESCRIPTION
Using the `$element` as the parent context when selecting options.
In this way, we can prevent select choosing options from other select boxes having similar values.